### PR TITLE
Treat __setstate__ errors during unpickling as cache misses

### DIFF
--- a/src/memoshelve/__init__.py
+++ b/src/memoshelve/__init__.py
@@ -182,8 +182,18 @@ def compact(
             for k in db.keys():
                 try:
                     entries[k] = db[k]
+                except (KeyboardInterrupt, SystemExit):
+                    raise
                 except UnpicklingError:
                     logger.warning(f"UnpicklingError for {k} in {filename}")
+                except Exception as e:
+                    tb = traceback.extract_tb(e.__traceback__)
+                    if any(f.name == "__setstate__" for f in tb):
+                        logger.warning(
+                            f"__setstate__ error for {k} in {filename}: {e}"
+                        )
+                    else:
+                        raise
     except Exception as e:
         _gdbm_error = getattr(_gdbm, "error", _gdbm_dummy_error)
         if not (
@@ -1017,14 +1027,27 @@ def make_make_get_raw(
                                 validate=validate,
                                 validate_warn=validate_warn,
                             )
-                        except RecursionError as e:
-                            try:
-                                del db[key]
-                            except (KeyboardInterrupt, SystemExit):
+                        except (KeyboardInterrupt, SystemExit):
+                            raise
+                        except Exception as e:
+                            tb = traceback.extract_tb(e.__traceback__)
+                            is_setstate = any(
+                                f.name == "__setstate__" for f in tb
+                            )
+                            if not is_setstate and (
+                                isinstance(e, _gdbm_error)
+                                or isinstance(e, dbm.error)
+                            ):
                                 raise
-                            except Exception:
-                                pass
-                            raise KeyError(e) from e
+                            if isinstance(e, RecursionError) or is_setstate:
+                                try:
+                                    del db[key]
+                                except (KeyboardInterrupt, SystemExit):
+                                    raise
+                                except Exception:
+                                    pass
+                                raise KeyError(e) from e
+                            raise
                     print_disk_cache_hit(f"Cache hit (disk: {filename}): {key}")
                     result = mem_db[mkey]
                     assert isinstance(result, dict), result

--- a/tests/test_memoshelve_integration.py
+++ b/tests/test_memoshelve_integration.py
@@ -402,5 +402,67 @@ class TestCustomHashStrategies:
         assert status == "cached (mem)"
 
 
+class TestSetstateUnpicklingError:
+    """Test that __setstate__ errors during unpickling are treated as cache misses."""
+
+    def test_setstate_error_treated_as_cache_miss(self, temp_dir):
+        """If __setstate__ raises during unpickling from disk, treat as a cache miss."""
+        import shelve
+        import pickle
+
+        cache_file = temp_dir / "setstate_error.shelve"
+        call_count = 0
+
+        class BadSetstate:
+            def __getstate__(self):
+                return {"ok": True}
+
+            def __setstate__(self, state):
+                raise FileNotFoundError("simulated missing file")
+
+        @cache(filename=cache_file)
+        def make_obj(x):
+            nonlocal call_count
+            call_count += 1
+            return BadSetstate()
+
+        # First call: computes and stores to disk
+        # The result is also kept in mem_db, so no unpickling needed yet
+        result = make_obj(42)
+        assert call_count == 1
+        assert isinstance(result, BadSetstate)
+
+        # Clear the in-memory cache dict that mem_db references
+        for v in memoshelve_cache.values():
+            v.clear()
+
+        # Second call: reads from disk, __setstate__ raises FileNotFoundError
+        # This should be treated as a cache miss, not crash
+        result2 = make_obj(42)
+        assert call_count == 2  # function was called again (cache miss)
+
+    def test_setstate_keyboard_interrupt_not_swallowed(self, temp_dir):
+        """KeyboardInterrupt in __setstate__ should propagate, not be treated as cache miss."""
+        cache_file = temp_dir / "setstate_kbi.shelve"
+
+        class KBISetstate:
+            def __getstate__(self):
+                return {"ok": True}
+
+            def __setstate__(self, state):
+                raise KeyboardInterrupt()
+
+        @cache(filename=cache_file)
+        def make_obj(x):
+            return KBISetstate()
+
+        make_obj(1)
+        for v in memoshelve_cache.values():
+            v.clear()
+
+        with pytest.raises(KeyboardInterrupt):
+            make_obj(1)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- When unpickling a cached value from disk triggers an exception inside `__setstate__` (e.g., `FileNotFoundError` for missing backing files), treat it as a cache miss instead of crashing. This generalizes the existing `RecursionError` handling to any exception originating from `__setstate__`.
- `KeyboardInterrupt`, `SystemExit`, and database errors (`_gdbm_error`/`dbm.error`) that don't come from `__setstate__` are still propagated.
- Also fixes `compact()` to skip entries whose `__setstate__` fails instead of crashing the entire compaction.

Fixes the traceback:
```
FileNotFoundError: [Errno 2] No such file or directory: '.../.cache/files/96/2e/88/58680d1bc22bacb899432adbb6'
```
occurring inside a `__setstate__` method during unpickling, which previously crashed instead of being treated as a cache miss.

## Test plan
- [x] Added `test_setstate_error_treated_as_cache_miss` — verifies that a `FileNotFoundError` in `__setstate__` during disk unpickling is treated as a cache miss and the function is recomputed
- [x] Added `test_setstate_keyboard_interrupt_not_swallowed` — verifies that `KeyboardInterrupt` in `__setstate__` still propagates
- [x] All 47 existing tests pass (plus 1 xfail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)