### PR TITLE
Fix 'db type could not be determined' race with inter-process flock

### DIFF
--- a/src/memoshelve/__init__.py
+++ b/src/memoshelve/__init__.py
@@ -3,6 +3,11 @@ try:
 except ImportError:
     _gdbm = None
 
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # Windows: flock is unavailable; locking degrades to a no-op
+
 from copy import deepcopy
 import inspect
 import logging
@@ -153,6 +158,45 @@ def validate_value_or_raise_and_warn(
     raise exn
 
 
+@contextmanager
+def _shelve_file_lock(filename: Path | str):
+    """Exclusive inter-process lock on a sidecar ``<filename>.lock`` file.
+
+    ``dbm.open`` determines the database type by reading the file with no
+    locking at all (``dbm.whichdb``), so a concurrent reader can observe a
+    half-created database -- e.g. a 0-byte file between gdbm's
+    ``open(O_CREAT)`` and its header write, or ``compact``'s
+    remove-and-recreate window -- and fail with
+    "db type could not be determined".  Holding this lock around every
+    ``shelve.open`` and for the duration of ``compact``/``upgrade`` makes
+    those states unobservable.
+
+    Not reentrant: code already holding the lock must call ``shelve.open``
+    directly rather than via ``_locked_shelve_open``.  Degrades to a no-op
+    where fcntl is unavailable (Windows).
+    """
+    if fcntl is None:
+        yield
+        return
+    fd = os.open(str(filename) + ".lock", os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _locked_shelve_open(filename: Path | str, *args, **kwargs) -> shelve.Shelf:
+    """``shelve.open`` under ``_shelve_file_lock``; the lock is released as
+    soon as the database is open (the dbm backend's own locking takes over
+    from there)."""
+    with _shelve_file_lock(filename):
+        return shelve.open(filename, *args, **kwargs)
+
+
 def compact(
     filename: Path | str,
     backup: bool = True,
@@ -177,66 +221,67 @@ def compact(
     """
     save_backup = False
     entries = {}
-    try:
-        with shelve.open(filename) as db:
-            for k in db.keys():
-                try:
-                    entries[k] = db[k]
-                except (KeyboardInterrupt, SystemExit):
-                    raise
-                except UnpicklingError:
-                    logger.warning(f"UnpicklingError for {k} in {filename}")
-                except Exception as e:
-                    tb = traceback.extract_tb(e.__traceback__)
-                    if any(f.name == "__setstate__" for f in tb):
-                        logger.warning(
-                            f"__setstate__ error for {k} in {filename}: {e}"
-                        )
-                    else:
+    with _shelve_file_lock(filename):
+        try:
+            with shelve.open(filename) as db:
+                for k in db.keys():
+                    try:
+                        entries[k] = db[k]
+                    except (KeyboardInterrupt, SystemExit):
                         raise
-    except Exception as e:
-        _gdbm_error = getattr(_gdbm, "error", _gdbm_dummy_error)
-        if not (
-            isinstance(e, _gdbm_error) or isinstance(e, dbm.error)
-        ):  # handle recovery
-            raise e
-        if not (
-            e.args
-            and isinstance(e.args, tuple)
-            and isinstance(e.args[0], str)
-            and e.args[0].startswith("db type could not be determined")
-            and remove_on_unknown_type
-        ):
-            raise e
-        backup = True
-        save_backup = True
-        logger.warning(
-            f"DB type could not be determined ({e}), removing {filename} and creating a new one"
-        )
-    if validate is not None and validate is not False:
-        for k, v in list(entries.items()):
-            try:
-                validate_value_or_raise_and_warn(
-                    v,
-                    validate=validate,
-                    key=k,
-                    filename=filename,
-                    exn=KeyError(),
-                    warn_fn=validate_warn,
-                )
-            except KeyError:
-                del entries[k]
-    if backup:
-        backup_name = backup_file(filename)
-    else:
-        backup_name = None
-        os.remove(filename)
-    with shelve.open(filename) as db:
-        for k in entries.keys():
-            db[k] = entries[k]
-    if backup_name and not save_backup:
-        assert backup_name != filename, backup_name
-        os.remove(backup_name)
+                    except UnpicklingError:
+                        logger.warning(f"UnpicklingError for {k} in {filename}")
+                    except Exception as e:
+                        tb = traceback.extract_tb(e.__traceback__)
+                        if any(f.name == "__setstate__" for f in tb):
+                            logger.warning(
+                                f"__setstate__ error for {k} in {filename}: {e}"
+                            )
+                        else:
+                            raise
+        except Exception as e:
+            _gdbm_error = getattr(_gdbm, "error", _gdbm_dummy_error)
+            if not (
+                isinstance(e, _gdbm_error) or isinstance(e, dbm.error)
+            ):  # handle recovery
+                raise e
+            if not (
+                e.args
+                and isinstance(e.args, tuple)
+                and isinstance(e.args[0], str)
+                and e.args[0].startswith("db type could not be determined")
+                and remove_on_unknown_type
+            ):
+                raise e
+            backup = True
+            save_backup = True
+            logger.warning(
+                f"DB type could not be determined ({e}), removing {filename} and creating a new one"
+            )
+        if validate is not None and validate is not False:
+            for k, v in list(entries.items()):
+                try:
+                    validate_value_or_raise_and_warn(
+                        v,
+                        validate=validate,
+                        key=k,
+                        filename=filename,
+                        exn=KeyError(),
+                        warn_fn=validate_warn,
+                    )
+                except KeyError:
+                    del entries[k]
+        if backup:
+            backup_name = backup_file(filename)
+        else:
+            backup_name = None
+            os.remove(filename)
+        with shelve.open(filename) as db:
+            for k in entries.keys():
+                db[k] = entries[k]
+        if backup_name and not save_backup:
+            assert backup_name != filename, backup_name
+            os.remove(backup_name)
 
 
 def upgrade_value(value: Any) -> Optional[dict]:
@@ -309,35 +354,36 @@ def upgrade(
         Various IO errors: From file operations
     """
     filename = Path(filename)
-    with shelve.open(filename) as db:
-        old_entries = dict(db.items())
+    with _shelve_file_lock(filename):
+        with shelve.open(filename) as db:
+            old_entries = dict(db.items())
 
-    entries = {}
-    remove_backup = True
-    for k, stored in old_entries.items():
-        new_value = upgrade_value(stored)
-        if new_value is not None:
-            new_key = (
-                str(new_hash((stored["args"], stored["kwargs"]))) if new_hash else k
-            )
-            entries[new_key] = new_value
+        entries = {}
+        remove_backup = True
+        for k, stored in old_entries.items():
+            new_value = upgrade_value(stored)
+            if new_value is not None:
+                new_key = (
+                    str(new_hash((stored["args"], stored["kwargs"]))) if new_hash else k
+                )
+                entries[new_key] = new_value
+            else:
+                remove_backup = remove_backup_on_failure
+                logger.warning(
+                    f"Skipping non-upgradable entry {k} with value {stored} in {filename}"
+                )
+
+        if backup:
+            backup_name = backup_file(filename)
         else:
-            remove_backup = remove_backup_on_failure
-            logger.warning(
-                f"Skipping non-upgradable entry {k} with value {stored} in {filename}"
-            )
-
-    if backup:
-        backup_name = backup_file(filename)
-    else:
-        backup_name = None
-        if filename.exists():
-            os.remove(filename)
-    with shelve.open(filename) as db:
-        for k, v in entries.items():
-            db[k] = v
-    if backup_name and remove_backup:
-        os.remove(backup_name)
+            backup_name = None
+            if filename.exists():
+                os.remove(filename)
+        with shelve.open(filename) as db:
+            for k, v in entries.items():
+                db[k] = v
+        if backup_name and remove_backup:
+            os.remove(backup_name)
 
 
 @contextmanager
@@ -364,7 +410,7 @@ def lazy_shelve_open(filename: Path | str, *, eager: bool = False):
         ```
     """
     if eager:
-        with shelve.open(filename) as db:
+        with _locked_shelve_open(filename) as db:
 
             @contextmanager
             def get_db():
@@ -379,7 +425,7 @@ def lazy_shelve_open(filename: Path | str, *, eager: bool = False):
             sh = None
             while sh is None:
                 try:
-                    sh = shelve.open(filename)
+                    sh = _locked_shelve_open(filename)
                 except Exception as e:
                     if e.args == (11, "Resource temporarily unavailable"):
                         time.sleep(0.1)
@@ -1566,7 +1612,7 @@ def uncache(
         invalidate_on_source_change=invalidate_on_source_change,
     )(*args, **kwargs)
 
-    with shelve.open(filename) as db:
+    with _locked_shelve_open(filename) as db:
         mkey = get_hash_mem(cache_tuple)
         if mkey in mem_db:
             del mem_db[mkey]

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -1,0 +1,129 @@
+"""
+Tests for inter-process file locking around shelve.open and compact.
+
+dbm.open() determines the database type by reading the file with no locking
+at all (dbm.whichdb), so a concurrent reader can observe a half-created
+database -- e.g. a 0-byte file between gdbm's open(O_CREAT) and its header
+write, or the window where compact() has renamed the file away and is
+recreating it -- and fail with "db type could not be determined".
+
+memoshelve guards against this by taking an exclusive flock on a sidecar
+``<filename>.lock`` file around every shelve.open and for the duration of
+compact()/upgrade().  These tests simulate the "creation in progress" state
+deterministically by holding that lock from another process.
+"""
+
+import multiprocessing
+import os
+import shelve
+import sys
+import time
+
+import pytest
+
+from memoshelve import compact, lazy_shelve_open
+
+if sys.platform != "win32":
+    import fcntl
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="flock-based locking is POSIX-only"
+)
+
+
+def _lock_path(filename):
+    return str(filename) + ".lock"
+
+
+def _hold_lock_with_half_created_db(filename, hold_seconds, started):
+    """Simulate a database mid-creation: hold the sidecar lock while the db
+    file exists but is 0 bytes (no header yet), then finish creating a valid
+    db and release the lock."""
+    fd = os.open(_lock_path(filename), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    with open(filename, "wb"):
+        pass  # 0 bytes: the state whichdb cannot identify
+    started.set()
+    time.sleep(hold_seconds)
+    os.remove(filename)
+    with shelve.open(filename) as db:
+        db["seeded"] = True
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+def _hold_lock(filename, hold_seconds, started):
+    fd = os.open(_lock_path(filename), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    started.set()
+    time.sleep(hold_seconds)
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+def _hold_db_open(filename, hold_seconds, started):
+    with shelve.open(filename) as db:
+        db["held"] = True
+        started.set()
+        time.sleep(hold_seconds)
+
+
+@pytest.mark.parametrize("eager", [False, True])
+def test_open_waits_for_in_progress_creation(tmp_path, eager):
+    """Opening must wait for the lock instead of reading a half-created file
+    and dying with 'db type could not be determined'."""
+    filename = str(tmp_path / "cache.shelve")
+    started = multiprocessing.Event()
+    p = multiprocessing.Process(
+        target=_hold_lock_with_half_created_db, args=(filename, 1.0, started)
+    )
+    p.start()
+    try:
+        assert started.wait(10)
+        t0 = time.monotonic()
+        with lazy_shelve_open(filename, eager=eager) as get_db:
+            with get_db() as db:
+                assert db["seeded"] is True
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.4, "open should have blocked on the lock"
+    finally:
+        p.join()
+
+
+def test_compact_waits_for_lock(tmp_path):
+    """compact() must hold the inter-process lock for its remove-and-recreate,
+    and therefore wait if someone else holds it."""
+    filename = str(tmp_path / "cache.shelve")
+    with shelve.open(filename) as db:
+        db["k"] = 1
+    started = multiprocessing.Event()
+    p = multiprocessing.Process(target=_hold_lock, args=(filename, 1.0, started))
+    p.start()
+    try:
+        assert started.wait(10)
+        t0 = time.monotonic()
+        compact(filename)
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.4, "compact should have blocked on the lock"
+    finally:
+        p.join()
+    with shelve.open(filename) as db:
+        assert db["k"] == 1
+
+
+def test_no_deadlock_when_db_held_open(tmp_path):
+    """The lock covers only the open itself, so a process that keeps the
+    shelve open (holding gdbm's own write lock) must not deadlock others."""
+    filename = str(tmp_path / "cache.shelve")
+    with shelve.open(filename) as db:
+        db["k"] = 1
+    started = multiprocessing.Event()
+    p = multiprocessing.Process(target=_hold_db_open, args=(filename, 1.0, started))
+    p.start()
+    try:
+        assert started.wait(10)
+        with lazy_shelve_open(filename) as get_db:
+            with get_db() as db:
+                assert db["k"] == 1
+    finally:
+        p.join()


### PR DESCRIPTION
## Problem

Under heavy multi-process use (observed with ~34 processes sharing `~/.cache/memoshelve/_run_cmd.shelve`), reads intermittently fail with:

```
WARNING: Error reading from .../_run_cmd.shelve, attempting compact: db type could not be determined
```

Root cause: `dbm.open()` determines the database type by reading the file with **no locking at all** (`dbm.whichdb`). gdbm's own flock only applies after gdbm opens the file. So a concurrent reader can observe a half-created database — a 0-byte file between gdbm's `open(O_CREAT)` and its header write, or `compact()`'s remove-and-recreate window — and fail with `dbm.error: db type could not be determined`. That error then triggers `compact(remove_on_unknown_type=True)`, which discards the cache, and concurrent compacts can delete each other's files and backups.

## Fix

Take an exclusive `flock` on a sidecar `<filename>.lock` file:

- around every `shelve.open` (released as soon as the database is open, so the dbm backend's own locking and the existing errno-11 retry loop still govern normal concurrent access — no serialization of cache use), and
- for the full duration of `compact()` and `upgrade()`, so their rename/remove-and-recreate windows are unobservable and concurrent compacts serialize.

Degrades to a no-op where `fcntl` is unavailable (Windows). Side effect: a small `<filename>.lock` sidecar file now appears next to each cache file.

## Tests

`tests/test_file_lock.py` simulates "creation in progress" deterministically (subprocess holds the sidecar lock while the db file is 0 bytes) and asserts that opens and compacts block on the lock instead of failing; plus a no-deadlock regression test for the gdbm-busy retry path. All tests were verified to fail with `dbm.error: db type could not be determined` (or no waiting) before the fix. Full suite: 51 passed, 1 xfailed. A 16-process create/remove stress run also passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)